### PR TITLE
Calculating CHECKSUM on views broke the execution.

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -40,7 +40,7 @@ func (h *MySQL) tableNames(q queryable) ([]string, error) {
 	query := `
 		SELECT table_name
 		FROM information_schema.tables
-		WHERE table_schema=?;
+		WHERE table_schema=? AND table_type='BASE TABLE';
 	`
 	dbName, err := h.databaseName(q)
 	if err != nil {


### PR DESCRIPTION
For avoid that when we retrive all tables inside the database we have to
filter only for the 'BASE TABLE', infact doesn't make sense
try to add data to any views.